### PR TITLE
Add Banca Intesa (Србија)

### DIFF
--- a/data/brands/amenity/bank.json
+++ b/data/brands/amenity/bank.json
@@ -8313,7 +8313,7 @@
       "id": "intesasanpaolo-efe23b",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["ua"]
+        "exclude": ["ua", "rs"]
       },
       "matchNames": [
         "banca intesa",
@@ -8332,6 +8332,22 @@
         "name": "Intesa Sanpaolo"
       }
     },
+    {
+      "displayName": "Banca Intesa (Србија)",
+      "id": "intesars-ad142c",
+      "locationSet": {
+        "include": ["rs"]
+      },
+      "matchNames": [
+        "intesa bank"
+      ],
+      "tags": {
+        "amenity": "bank",
+        "brand": "Banca Intesa",
+        "brand:wikidata": "Q2882046",
+        "name": "Banca Intesa"
+      }
+    },    
     {
       "displayName": "Investors Bank",
       "id": "investorsbank-ea2e2d",


### PR DESCRIPTION
Right now OSM iD editor incorrectly suggests Intesa Sanpaolo.